### PR TITLE
change the output to a prittyer format

### DIFF
--- a/custom_components/wienerlinien/sensor.py
+++ b/custom_components/wienerlinien/sensor.py
@@ -79,7 +79,7 @@ class WienerlinienSensor(Entity):
             if firstDeparture == 'N/A':
                 self._state = DepartureTowards
             else: 
-                self._state = DepartureTowards + ' in ' + str(firstDeparture) + 'min(s) ' + DepartureTowards + ' in ' + str(nextDeparture) + 'min(s)'
+                self._state = ' ' + str(firstDeparture) + ' und in  ' + ' ' + str(nextDeparture) + ' Minuten Richtung '+ DepartureTowards
             self._firstdeparture = firstDeparture
             self._nextdeparture = nextDeparture
 


### PR DESCRIPTION
The RBL's are in one direction only, printing out ` DepartureTowards` two times shouldn't be needed.