### PR TITLE
Fixing issues in setting up the dev container

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,6 +1,6 @@
 default_config:
 logger:
-  default: error
+  default: warning
   logs:
     custom_components.wienerlinien: debug
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,25 +4,25 @@
 	"context": "..",
 	"postCreateCommand": "make init",
 	"appPort": [
-	  "9123:8123"
+		"9123:8123"
 	],
 	"extensions": [
-	  "ms-python.python",
-	  "github.vscode-pull-request-github",
-	  "ryanluker.vscode-coverage-gutters",
-	  "ms-python.vscode-pylance"
+		"ms-python.python",
+		"github.vscode-pull-request-github",
+		"ryanluker.vscode-coverage-gutters",
+		"ms-python.vscode-pylance"
 	],
 	"settings": {
-	  "files.eol": "\n",
-	  "editor.tabSize": 4,
-	  "terminal.integrated.shell.linux": "/bin/bash",
-	  "python.pythonPath": "/usr/bin/python3",
-	  "python.linting.pylintEnabled": true,
-	  "python.linting.enabled": true,
-	  "python.formatting.provider": "black",
-	  "editor.formatOnPaste": false,
-	  "editor.formatOnSave": true,
-	  "editor.formatOnType": true,
-	  "files.trimTrailingWhitespace": true
+		"files.eol": "\n",
+		"editor.tabSize": 4,
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/bin/python3",
+		"python.linting.pylintEnabled": true,
+		"python.linting.enabled": true,
+		"python.formatting.provider": "black",
+		"editor.formatOnPaste": false,
+		"editor.formatOnSave": true,
+		"editor.formatOnType": true,
+		"files.trimTrailingWhitespace": true
 	}
-  } 
+}

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ init: homeassistant-install requirements
 
 requirements:
 ifdef HAS_APK
-	apk add libxml2-dev libxslt-dev
+	apk add libxml2-dev libxslt-dev g++ tzdata
 endif
 ifdef HAS_APT
-	sudo apt update && sudo apt install libxml2-dev libxslt-dev
+	sudo apt update && sudo apt install libxml2-dev libxslt-dev g++ tzdata
 endif
 	python3 -m pip --disable-pip-version-check install -U setuptools wheel
-	python3 -m pip --disable-pip-version-check install -r requirements.txt
+	python3 -m pip --disable-pip-version-check install --ignore-installed distlib -r requirements.txt
 
 start: ## Start the HA with the integration
 	@bash .devcontainer/integration_start;


### PR DESCRIPTION
While setting up the development environment for this extension I recognized that the devcontainer is not working with recent versions/images. Therefore I did the following adjustments. 

- Added missing apt packages tzdata and g++
- Configures installation of requirements to ignore disttool installation
- changed the default logger level to warning to better follow the installation packet

Please consider this for pulling into the master branch