### PR TITLE
Debugging configuration added

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -4,6 +4,7 @@ logger:
   logs:
     custom_components.wienerlinien: debug
 
+debugpy:
 
 sensor:
   - platform: wienerlinien

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Running Home Assistant",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "processId": "${command:pickProcess}",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
To enable debugging by attaching the python debugger to the hass process I added a launch config for vscode + the debugpy option to home assistant configuration. Please consider for merging as this also simplifies the setup of a dev environment and does not significantly impact the performance of hass on the test environment.