### PR TITLE
Added vscode launch configuration to debug

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -4,6 +4,7 @@ logger:
   logs:
     custom_components.wienerlinien: debug
 
+debugpy:
 
 sensor:
   - platform: wienerlinien

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "wienerlinien development",
-	"image": "ludeeus/container:integration",
+	"image": "ghcr.io/ludeeus/devcontainer/integration:stable",
 	"context": "..",
 	"postCreateCommand": "make init",
 	"appPort": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Running Home Assistant",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "processId": "${command:pickProcess}",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
To enable debugging by attaching the python debugger to the hass process I added a launch config for vscode + the debugpy option to home assistant configuration. Please consider for merging as this also simplifies the setup of a dev environment and does not significantly impact the performance of hass on the test environment:

- Added configuration "debugpy" to hass config
- Added launch.json file with basic debugger attaching config

The created launch configuration allows attaching a python debugger to
any of the running processes. The list of processes is provided by
vscode when launching the configuration from the IDE.